### PR TITLE
address numpy and scipy deprecations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,10 @@
 # To use:
 #   conda env create -f .\environment.yml
 # and then
-#   conda activate structcol
+#   conda activate pymie
 #
 # To update dependencies after changing this environment file:
-#   conda env update --name structcol --file environment.yml --prune
+#   conda env update --name pymie --file environment.yml --prune
 #
 # can also use mamba instead of conda in the above
 name: pymie

--- a/pymie/mie.py
+++ b/pymie/mie.py
@@ -43,7 +43,7 @@ import warnings
 
 import numpy as np
 from scipy.special import spherical_jn, spherical_yn
-from scipy.special import legendre_p_all, lpn
+from scipy.special import legendre_p_all
 from scipy.integrate import trapezoid
 
 from . import Quantity, index_ratio, mie_specfuncs
@@ -440,8 +440,8 @@ def _pis_and_taus(nstop, thetas):
 
     mu = np.cos(thetas)
 
-    # returns P_n and derivatives up to degree n for all values in mu array has
-    # shape (2, nmax, len(mu)), where legendre0[0,:,:] is P_n and
+    # returns P_n and derivatives up to degree n for all values in mu array.
+    # legendre0 has shape (2, nmax, len(mu)), where legendre0[0,:,:] is P_n and
     # legendre0[1,:,:] is the derivative.
     legendre0 = legendre_p_all(nstop, mu, diff_n=1)
 

--- a/pymie/tests/test_multilayer.py
+++ b/pymie/tests/test_multilayer.py
@@ -110,8 +110,9 @@ def test_sooty_particles():
     location = os.path.split(os.path.abspath(__file__))[0]
     gold_name = os.path.join(location, 'gold',
                              'gold_multilayer')
-    gold = np.array(yaml.safe_load(open(gold_name + '.yaml')))
-
+    gold_file = open(gold_name + '.yaml')
+    gold = np.array(yaml.safe_load(gold_file))
+    gold_file.close()
 
     assert_allclose(efficiencies_from_scat_units(m_ac, x_ac), gold[0],
                     rtol = 1e-3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# convert all warnings to errors
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+]


### PR DESCRIPTION
This PR removes functions that are deprecated in numpy 2.0, numpy 2.2, and scipy 1.15 and replaces them with the recommended versions.  In particular:

- `scipy.special.legendre_p_all()` is now used to calculate the Legendre polynomials, replacing the deprecated `scipy.special.lpn()`.  This change should speed up the calculations, since `scipy.special.lpn()` was not a ufunc, and we had to manually vectorize it (the vectorization essentially used a `for` loop).  Since `scipy.special.legendre_p_all()` is a ufunc, I've removed the old vectorization code.
- `scipy.integrate.trapezoid()` is used for numerical integration, replacing the deprecated `np.trapz()`.  Unfortunately, `scipy.integrate.trapezoid()` does not preserve `pint`'s units (whereas `np.trapz()` did), so I added some code to remove the units before integration and put them back afterward.

The PR also configures `pytest` to treat all warnings as errors, which will force us to correct deprecations and will flag code that implicitly removes units.

Tests pass on Windows and Linux.  I have not tested on MacOS, and I haven't tested `structcol` with these changes yet.